### PR TITLE
Response callback feature

### DIFF
--- a/lib/url_validation.rb
+++ b/lib/url_validation.rb
@@ -130,7 +130,7 @@ class UrlValidator < ActiveModel::EachValidator
     
     record.errors.add(attribute, options[:invalid_url_message]          || :invalid_url)          unless url_format_valid?(uri, options)
     record.errors.add(attribute, options[:url_not_accessible_message]   || :url_not_accessible)   unless response = url_accessible?(uri, options)
-    record.errors.add(attribute, options[:url_invalid_response_message] || :url_invalid_response) unless url_response_valid?(response, options)
+    record.errors.add(attribute, options[:url_invalid_response_message] || :url_invalid_response) unless url_response_valid?(response, record, attribute, value, options)
   end
   
   private
@@ -175,9 +175,9 @@ class UrlValidator < ActiveModel::EachValidator
     return false
   end
   
-  def url_response_valid?(response, options)
+  def url_response_valid?(response, record, attribute, value, options)
     return true unless response.kind_of?(HTTPI::Response) and options[:check_path]
-    options[:response_callback].call(response) if options[:response_callback].respond_to?(:call)
+    options[:response_callback].call(response, record, attribute, value) if options[:response_callback].respond_to?(:call)
     response_codes = options[:check_path] == true ? [400..499, 500..599] : Array.wrap(options[:check_path]).flatten
     return response_codes.none? do |code| # it's good if it's not a bad response
       case code # and it's a bad response if...

--- a/spec/url_validator_spec.rb
+++ b/spec/url_validator_spec.rb
@@ -231,7 +231,7 @@ describe UrlValidator do
     context "[:response_callback]" do
       it "should be yielded the HTTPI response" do
         called = false
-        @validator = UrlValidator.new(:attributes => [ :field ], :check_path => true, :response_callback => lambda { |response| called = true; response.should be_kind_of(HTTPI::Response) })
+        @validator = UrlValidator.new(:attributes => [ :field ], :check_path => true, :response_callback => lambda { |response, record, attribute, value| called = true; response.should be_kind_of(HTTPI::Response) })
         @validator.validate_each(@record, :field, "http://www.google.com/sdgsdgf")
         called.should be_true
       end


### PR DESCRIPTION
Added another option +response_callback+ similar to the +request_callback+ option.  Also passing record, attribute, and value in order to act on the parent object.  Currently using this to update the validated url when a 3xx response is received.
